### PR TITLE
Patch select background color

### DIFF
--- a/openrepairplatform/static/scss/includes/_forms.scss
+++ b/openrepairplatform/static/scss/includes/_forms.scss
@@ -58,5 +58,5 @@
 
 .select2-container--default
   .select2-results__option--highlighted[aria-selected] {
-  //background-color: $primary !important;
+  background-color: $secondary !important;
 }


### PR DESCRIPTION
Changement du fond des selects qui était noir, avec du texte noir par dessus.
Avant :
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/05435579-9317-4df3-9c70-7925eaa3d55e" />
Après :
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/0a6751fd-21af-41fa-901f-58d2bd0fcf6e" />
