### PR TITLE
Edit django settings : remove session expiration on browser (#175)

### DIFF
--- a/openrepairplatform/settings/base.py
+++ b/openrepairplatform/settings/base.py
@@ -150,6 +150,9 @@ EMAIL_FILE_PATH = join(BASE_DIR, "tmp", "messages")
 
 AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
+# Session settings
+SESSION_EXPIRE_AT_BROWSER_CLOSE = False
+
 # Config django-assets
 ASSETS_MODULES = ["openrepairplatform.assets"]
 


### PR DESCRIPTION
Modification d'un paramètre de django qui change la manière dont la session est stocké. Normalement le code postal reste même après avoir fermé le navigateur
(Voir #175)