### PR TITLE
Add Sentry integration for error tracking in development

### DIFF
--- a/openrepairplatform/settings/base.py
+++ b/openrepairplatform/settings/base.py
@@ -175,7 +175,7 @@ SESSION_COOKIE_AGE =2419200
 
 
 DEBUG = os.getenv("DEBUG", "False").lower() in ('true', '1', 'y')
-if not DEBUG and os.getenv("SENTRY_DNS"):
+if not DEBUG and os.getenv("SENTRY_DSN"):
     import sentry_sdk
     sentry_sdk.init(
         dsn=os.getenv("SENTRY_DSN"),


### PR DESCRIPTION
- Added `sentry-sdk[django]` to `requirements_dev.txt`.
- Configured Sentry in `dev.py` to initialize when `DEBUG` is false and `SENTRY_DSN` is set.