### PR TITLE
Edit logout button to replace it with a form to call it with a post request

### DIFF
--- a/openrepairplatform/templates/menu.html
+++ b/openrepairplatform/templates/menu.html
@@ -135,7 +135,12 @@
                   {% endif %}
                 </li>
                 <li>
-                  <a class="dropdown-item" href="{% url 'logout' %}" title="Logout">Déconnexion</a>
+                    <form method="post" action="{% url 'logout' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="dropdown-item">
+                            <a>Déconnexion</a>
+                        </button>
+                    </form>
                 </li>
               </ul>
             {% endif %}


### PR DESCRIPTION
Since the django 5.2 upgrade, the logout doesn't work any more because it is a "post" only route.
I replace the link with a form, to call the route in "post"
fix #384 