### PR TITLE
On event administration page, add two buttons : one to copy the mails of the participants and one to send a mail to theme

### DIFF
--- a/openrepairplatform/event/templates/event/event_detail.html
+++ b/openrepairplatform/event/templates/event/event_detail.html
@@ -27,6 +27,22 @@
           {% if request.get_full_path == the_url %}
             <a href="{{ event.get_absolute_url }}"
                class="btn btn-large btn-light me-2 mb-2 ">Ne plus administrer</a>
+            <div class="btn-group">
+              <button type="button" class="m-2 btn btn-light dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <i class="far fa-envelope"></i> Mail aux participants
+              </button>
+              <div class="dropdown-menu" aria-labelledby="btnGroupDrop2">
+                  <a href="mailto:{{ emails_list|join:"," }}" class="dropdown-item">Envoyer un mail</a>
+                  <a href="#" onclick="navigator.clipboard.writeText('{{ emails_list|join:"," }}');$('#liveToast').css('right','0px')" class="dropdown-item">Copier les mails</a>
+              </div>
+                <div class="alert alert-info alert-dismissible alert-stay fade show mb-0" role="alert" id="liveToast">
+                    Copié !
+                    <button type="button" class="close" aria-label="Close" onclick="$('#liveToast').css('right','-1000px')">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+
+            </div>
             {% include "event/invitation.html" %}
           {% else %}
             <a href="admin" class="btn btn-large btn-light me-2 mb-2 ">

--- a/openrepairplatform/event/views/event_manager.py
+++ b/openrepairplatform/event/views/event_manager.py
@@ -77,6 +77,9 @@ class EventAdminView(HasVolunteerPermissionMixin, EventViewMixin):
             (f"{user.email} ({user.first_name} {user.last_name})", user.email)
             for user in CustomUser.objects.only("email", "first_name", "last_name")
         ]
+
+        context["emails_list"] = [user.email for user in context["event"].registered.all()]
+
         context["present_form"] = MoreInfoCustomUserForm
         context["total_fees"] = sum(
             [fee.amount for fee in self.get_object().fees.all()]

--- a/openrepairplatform/static/js/lib/auto-dissmiss-alerts.js
+++ b/openrepairplatform/static/js/lib/auto-dissmiss-alerts.js
@@ -1,8 +1,8 @@
   window.setTimeout(function() {
-    $(".alert").css("right",'-1000px').slideUp(1000, function(){
+    $(".alert:not(.alert-stay)").css("right",'-1000px').slideUp(1000, function(){
         $(this).remove(); 
     });
   }, 4000);
   $(document).ready(function(){
-      $(".alert").css("right",'0px');
-  });  
+      $(".alert:not(.alert-stay)").css("right",'0px');
+  });


### PR DESCRIPTION
<img width="957" height="354" alt="image" src="https://github.com/user-attachments/assets/2767f84d-47e1-463d-8e74-9473ec8f337a" />

fix #283 ?